### PR TITLE
usability: search xdg paths for style.css

### DIFF
--- a/source.c
+++ b/source.c
@@ -3,11 +3,13 @@
 #include <assert.h>
 #include <sys/wait.h>
 #include <gtk/gtk.h>
+#include <stdio.h>
 
 #include "auth.h"
 #include "window.h"
 #include "gtklock.h"
 #include "module.h"
+#include "xdg.h"
 
 struct GtkLock *gtklock = NULL;
 
@@ -158,7 +160,15 @@ int main(int argc, char **argv) {
 	gtklock->use_layer_shell = !no_layer_shell;
 	gtklock->use_input_inhibit = !no_input_inhibit;
 
-	if(style_path != NULL) attach_custom_style(style_path);
+    if(style_path == NULL){
+        style_path = resolve_xdg_style_path();
+        if(style_path) {
+            printf("gtklock: using %s for styles\n", style_path);
+            attach_custom_style(style_path);
+            free(style_path);
+        }
+    }
+
 	GModule *module = NULL;
 	if(module_path != NULL) module = module_load(module_path);
 

--- a/xdg.c
+++ b/xdg.c
@@ -1,0 +1,83 @@
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <linux/limits.h>
+#include <sys/stat.h>
+
+#define HOME_STYLE_SUFFIX "/.config/gtklock/style.css"
+#define ETC_STYLE_PATH "/etc/gtklock/style.css"
+
+/* resolve_xdg_style_path_home will perform a lookup of the current user's data
+   to discover their home directory. 
+
+   once the home discovery is discovered, a lookup of '~/.config/gtklock/style.css'
+   is performed. 
+
+   if discovered the fully resolved path is returned, if not nil is returned.
+
+   the caller should free the returned pointer when there is no longer use for it.
+*/
+char* resolve_xdg_style_path_home() {
+    char *style_path = calloc(PATH_MAX, sizeof(char));
+
+    uid_t euid = geteuid();
+    struct passwd *pwd = getpwuid(euid);
+    if(!pwd)
+        goto null;
+    strcpy(style_path, pwd->pw_dir);
+    strcat(style_path, HOME_STYLE_SUFFIX);
+    
+    struct stat s;
+    if(stat(style_path, &s) == -1)
+        goto null;
+
+    if(S_ISREG(s.st_mode) || S_ISLNK(s.st_mode)) {
+        return style_path;
+    }
+
+null:
+    free(style_path);
+    return NULL;
+};
+
+/* resolve_xdg_style_path_etc will perform a lookup of "style.css" in the canonical
+   "/etc/gtklock" directory
+
+   if discovered the fully resolved path is returned, if not nil is returned.
+
+   the caller should free the returned pointer when there is no longer use for it.
+*/
+char* resolve_xdg_style_path_etc() {
+    // we could pass back just the global ETC_STYLE_PATH but lets do this so
+    // the usage of free is consistent with resolve_xdg_style_path_home.
+    char *style_path = calloc(sizeof(ETC_STYLE_PATH), sizeof(char));
+
+    strcpy(style_path, ETC_STYLE_PATH);
+
+    struct stat s;
+    if(stat(style_path, &s) == -1)
+        goto null;
+
+    if(S_ISREG(s.st_mode) || S_ISLNK(s.st_mode)) {
+        return style_path;
+    }
+
+null:
+    free(style_path);
+    return NULL;
+};
+
+char* resolve_xdg_style_path() {
+    char *style_path;
+    // prefer user directory
+    style_path = resolve_xdg_style_path_home();
+    if(style_path)
+        return style_path;
+    // then etc directory
+    style_path = resolve_xdg_style_path_home();
+    if(style_path)
+        return style_path;
+    return NULL;
+}

--- a/xdg.h
+++ b/xdg.h
@@ -1,0 +1,11 @@
+#pragma once
+
+/* resolve_xdg_style_path will attempt to discover a style.css using the XDG
+   standard directories 
+
+   if a style path is discovered the returned pointer is non-nil and points to 
+   a string containing the path to style.css
+
+   if not path is found a nil is returned.
+*/
+char* resolve_xdg_style_path();


### PR DESCRIPTION
this pull request provides a search of both "/etc/gtklock/style.css" and
"~/.config/gtklock/style.css", such that the command line flag to load
style is no longer necessary.

Signed-off-by: ldelossa <louis.delos@gmail.com>