### PR TITLE
Add Gentoo Install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ make
 ### Install dependencies
 - Arch: `pacman -S gcc make pkgconf scdoc pam wayland gtk3 gtk-layer-shell`
 - Fedora: `dnf install gcc make pkgconf scdoc pam-devel wayland-devel gtk3-devel gtk-layer-shell-devel`
+- Gentoo: `emerge --ask gui-apps/gtklock` (in [GURU repository](https://wiki.gentoo.org/wiki/Project:GURU))
 - Void: `xbps-install gcc make pkgconf scdoc pam-devel wayland-devel gtk+3-devel gtk-layer-shell-devel`
 
 ❤️ __Please submit an installation command for your distro!__


### PR DESCRIPTION
Hello,

I packaged gtklock for Gentoo in the GURU overlay (similar to AUR for Arch), this PR adds the instructions to the README

Thanks for the great work on this program!