### PR TITLE
Update installation instructions with the official Arch packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ gtklock is available on these repositories:
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/gtklock.svg)](https://repology.org/project/gtklock/versions)
 
-- Arch: `# yay -S gtklock` (using [Yay](https://github.com/Jguer/yay))
+- Arch: `# pacman -S gtklock`
 - Gentoo: `# emerge --ask gui-apps/gtklock` (in [GURU repository](https://wiki.gentoo.org/wiki/Project:GURU))
 - Void: `# xbps-install gtklock`
 
@@ -34,7 +34,7 @@ $ ninja -C builddir
 - gtk+3.0
 - [gtk-session-lock](https://github.com/Cu3PO42/gtk-session-lock)
 ### Installing build dependencies
-- Arch: `# yay -S gcc meson pkgconf scdoc pam wayland gtk3 gtk-session-lock`
+- Arch: `# pacman -S gcc meson pkgconf scdoc pam wayland gtk3 gtk-session-lock`
 - Fedora: `# dnf install gcc meson pkgconf scdoc pam-devel wayland-devel gtk3-devel`, install gtk-session-lock manually
 - Void: `# xbps-install gcc meson pkgconf scdoc pam-devel wayland-devel gtk+3-devel gtk-session-lock-devel`
 


### PR DESCRIPTION
gtklock and all its build dependencies are now in the official Arch [extra] repository (they've been moved out of the AUR as part of the official packaging of the [nwg-shell in Arch repos](https://github.com/nwg-piotr/nwg-shell/discussions/374)).

This PR updates the installation instructions accordingly.