### PR TITLE
Add missing feature test macro to fix musl build

### DIFF
--- a/src/gtklock.c
+++ b/src/gtklock.c
@@ -3,6 +3,7 @@
 
 // gtklock application
 
+#define _POSIX_C_SOURCE
 #include <signal.h>
 #include <gtk/gtk.h>
 


### PR DESCRIPTION
_POSIX_C_SOURCE should be defined to ensure declaration of kill(2) is included. This fixes build on musl libc.

Link: https://www.man7.org/linux/man-pages/man2/kill.2.html#SYNOPSIS